### PR TITLE
user data request added

### DIFF
--- a/src/layout/navbar/components/SearchInput.tsx
+++ b/src/layout/navbar/components/SearchInput.tsx
@@ -1,5 +1,8 @@
-import apiConstants from "services/apiUrlsAndData";
-import useRequestRepoSearchAPI from "services/useRequestRepoSearchAPI";
+import {
+  apiConstants,
+  useRequestRepoSearchAPI,
+  useRequestUserSearchAPI,
+} from "services";
 import { SpinnerCircularFixed } from "spinners-react";
 
 import SearchIcon from "@mui/icons-material/Search";
@@ -7,15 +10,31 @@ import SearchIcon from "@mui/icons-material/Search";
 import styles from "./SearchInput.module.css";
 
 const SearchInput = () => {
-  const { data, isLoading, error, handleRepoSearchRequest } =
-    useRequestRepoSearchAPI();
+  const {
+    data: repoData,
+    isLoading: repoIsLoading,
+    error: repoError,
+    handleRepoSearchRequest,
+  } = useRequestRepoSearchAPI();
+  const {
+    data: userData,
+    isLoading: userIsLoading,
+    error: userError,
+    handleUserSearchRequest,
+  } = useRequestUserSearchAPI();
 
-  console.log({ data, isLoading, error });
+  console.log(
+    { repoData, repoIsLoading, repoError },
+    { userData, userIsLoading, userError }
+  );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.value.length >= 3) {
       handleRepoSearchRequest(
         `${apiConstants.apiURLs.repoSearchURL}${event.target.value}`
+      );
+      handleUserSearchRequest(
+        `${apiConstants.apiURLs.userSearchURL}${event.target.value}`
       );
     }
   };
@@ -34,7 +53,7 @@ const SearchInput = () => {
         color="#fff"
         secondaryColor="rgba(0,0,0,0.11)"
         thickness={150}
-        enabled={isLoading}
+        enabled={repoIsLoading || userIsLoading}
       />
     </div>
   );

--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -1,0 +1,3 @@
+export { default as apiConstants } from "./apiUrlsAndData";
+export { default as useRequestRepoSearchAPI } from "./useRequestRepoSearchAPI";
+export { default as useRequestUserSearchAPI } from "./useRequestUserSearchAPI";

--- a/src/services/useRequestUserSearchAPI.tsx
+++ b/src/services/useRequestUserSearchAPI.tsx
@@ -3,34 +3,35 @@ import axios from "axios";
 
 import { apiConstants } from "./";
 
-const useRequestRepoSearchAPI = () => {
+const useRequestUserSearchAPI = () => {
   const [data, setData] = useState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<null | undefined | string>(null);
 
-  const handleRepoSearchRequest = async (URL: string) => {
+  const handleUserSearchRequest = async (URL: string) => {
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await axios.get(URL);
-      const repodata = response.data.items;
+      const userdata = response.data.items;
 
-      if (typeof repodata === undefined || null) {
+      if (typeof userdata === undefined || null) {
         setError(apiConstants.responseMessage.unknown);
-      } else if (repodata.length <= 0) {
+      } else if (userdata.length <= 0) {
         setError(apiConstants.responseMessage.empty);
       } else {
-        const transRepos = repodata.map(
-          (repoData: { [key: string]: string }) => {
+        const transUsers = userdata.map(
+          (userData: { [key: string]: string }) => {
             return {
-              repoId: repoData.id,
-              repoTitle: repoData.full_name,
-              repoText: repoData.description,
+              userId: userData.id,
+              userTitle: userData.login,
+              userText: userData.html_url,
+              userImgUrl: userData.avatar_url,
             };
           }
         );
-        setData(transRepos);
+        setData(transUsers);
       }
     } catch (err: any) {
       setError(err.message || apiConstants.responseMessage.unknown);
@@ -38,7 +39,7 @@ const useRequestRepoSearchAPI = () => {
     setIsLoading(false);
   };
 
-  return { data, isLoading, error, handleRepoSearchRequest };
+  return { data, isLoading, error, handleUserSearchRequest };
 };
 
-export default useRequestRepoSearchAPI;
+export default useRequestUserSearchAPI;


### PR DESCRIPTION
Although it feels like it is against the nature of the custom hooks, I had to create another custom hook as `useRequestUserSearchAPI` which is pretty similar to `useRequestRepoSearchAPI` which differs on the mapped data properties.
My first approach was to use a single custom hook as `useRequestSearchAPI` and use it in `SearchInput` component and implement the separation of requests in the component unfortunately this approach brings me to a situation with more lines of codes and duplicates. It seems now pretty obvious that there are fewer codes in the `SearchInput`component but we now have two different custom hooks. 

There are 3 more cases of API requests which are not related to the input field, therefore, I left them. 